### PR TITLE
switches directory for binary to avoid shell errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const core = require('@actions/core')
+const io = require('@actions/io')
 const { exec } = require('@actions/exec')
 const https = require('https')
 
@@ -67,12 +68,13 @@ const get = url => {
 
 const run = async () => {
   const url = await fetchReleases()
+  const destinationFolder = './bin'
 
+  await io.mkdirP(destinationFolder);
   await exec(`wget --quiet ${url} -O jsonnet.tar.gz`)
-  await exec('mkdir -p jsonnet/bin/')
-  await exec('tar xvf jsonnet.tar.gz --directory jsonnet/bin/')
+  await exec(`tar xvf jsonnet.tar.gz --directory ${destinationFolder}`)
   await exec('rm jsonnet.tar.gz')
-  core.addPath('jsonnet/bin/')
+  core.addPath(destinationFolder)
 }
 
 try {


### PR DESCRIPTION
for projects that have a `jsonnet` directory at the root of the repo, the `setup-jsonnet` function will fail with `/home/runner/_work/<repo>/<repo>/jsonnet: Is a directory`

this PR moves the `jsonnet` binaries to `/home/actions/bin/` to avoid this issue