### PR TITLE
moves installation and PATH setup to BASH script

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const core = require('@actions/core')
 const io = require('@actions/io')
 const { exec } = require('@actions/exec')
 const https = require('https')
+const path = require('path')
 
 const fetchReleases = async () => {
   const version = core.getInput('version')
@@ -68,13 +69,8 @@ const get = url => {
 
 const run = async () => {
   const url = await fetchReleases()
-  const destinationFolder = './bin'
 
-  await io.mkdirP(destinationFolder);
-  await exec(`wget --quiet ${url} -O jsonnet.tar.gz`)
-  await exec(`tar xvf jsonnet.tar.gz --directory ${destinationFolder}`)
-  await exec('rm jsonnet.tar.gz')
-  core.addPath(destinationFolder)
+  await exec(path.join(__dirname, 'install-jsonnet.sh'), [url])
 }
 
 try {

--- a/install-jsonnet.sh
+++ b/install-jsonnet.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+
+echo "Downloading Jsonnet from: $1"
+wget --quiet $1 -O jsonnet.tar.gz
+
+mkdir bin
+tar xvf jsonnet.tar.gz --directory bin
+rm -f jsonnet.tar.gz
+
+# Add executables to the path for future actions
+echo "::add-path::$(pwd)/bin"


### PR DESCRIPTION
previous iteration was adding `.bin/` to the PATH, which only worked if your working directory was one directory above `.bin/`. if you set a different `working-directory` on your action, `jsonnet` couldn't be found in the PATH.

tried solving this entirely within NodeJS but had issues with ENV VARs and `pwd`, so moving this to a separate BASH script for now.