### PR TITLE
install go-jsonnet

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,9 +68,10 @@ const get = url => {
 }
 
 const run = async () => {
-  const url = await fetchReleases()
+  //const url = await fetchReleases()
 
-  await exec(path.join(__dirname, 'install-jsonnet.sh'), [url])
+  //await exec(path.join(__dirname, 'install-jsonnet.sh'), [url])
+  await exec(path.join(__dirname, 'install-jsonnet.sh'))
 }
 
 try {

--- a/install-jsonnet.sh
+++ b/install-jsonnet.sh
@@ -1,11 +1,8 @@
 #!/bin/bash -ex
 
-echo "Downloading Jsonnet from: $1"
-wget --quiet "$1" -O jsonnet.tar.gz
-
-mkdir -p bin
-tar xvf jsonnet.tar.gz --directory bin
-rm -f jsonnet.tar.gz
+# Install go-jsonnet
+go get github.com/google/go-jsonnet/cmd/jsonnet
+go get github.com/google/go-jsonnet/cmd/jsonnetfmt
 
 # Add jsonnet executables to the path for future actions
-echo "$(pwd)/bin" >> "$GITHUB_PATH"
+echo "$HOME/go/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
I'm not sure if we want to (or need to) support older versions of jsonnet -- I've made this change to support using `go-jsonnet` which is quite a bit quicker than the c++ variant.

I'm perfectly content leaving this in a dedicated branch, so folks can reference it like:
```
uses: zendesk/setup-jsonnet@go-jsonnet
```