### PR TITLE
Remove unused code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: zendesk/checkout@v2
+      - uses: zendesk/setup-go@v2
+        with:
+          go-version: '^1.16.0' # Go >= 1.16 to have go install
       - name: Setup Jsonnet
         uses: ./
         with:
-          version: v0.15.0
+          version: v0.16.12
           github_token: ${{ github.token }}
       - name: Print Jsonnet version
         run: jsonnet -v
@@ -23,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: zendesk/checkout@v2
+      - uses: zendesk/setup-go@v2
+        with:
+          go-version: '^1.16.0' # Go >= 1.16 to have go install
       - name: Setup Jsonnet
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ jobs:
   install_specific_version:
     name: Install specific version of Jsonnet and print version
     runs-on: ubuntu-latest
+    env:
+      version: v0.16.0
     steps:
       - uses: zendesk/checkout@v2
       - uses: zendesk/setup-go@v2
@@ -14,12 +16,24 @@ jobs:
       - name: Setup Jsonnet
         uses: ./
         with:
-          version: v0.16.12
+          version: ${{ env.version }}
           github_token: ${{ github.token }}
       - name: Print Jsonnet version
-        run: jsonnet -v
+        run: |
+          jsonnet_version=$(jsonnet -v)
+          echo "$jsonnet_version"
+          if [[ ${jsonnet_version} != *"$version"* ]];then
+            echo "Cannot find $version"
+            echo 1
+          fi
       - name: Print Jsonnet reformatter version
-        run: jsonnetfmt -v
+        run: |
+          jsonnet_version=$(jsonnetfmt -v)
+          echo "$jsonnet_version"
+          if [[ ${jsonnet_version} != *"$version"* ]];then
+            echo "Cannot find $version"
+            echo 1
+          fi
 
   install_latest:
     name: Install latest version of Jsonnet and print version

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Latest Release](https://img.shields.io/github/v/release/zendesk/setup-jsonnet?label=Latest%20Release)
 ![Examples](https://github.com/zendesk/setup-jsonnet/workflows/Test/badge.svg?branch=master)
 
-A GitHub action to install a specific version of Jsonnet. This action will add
+A GitHub action to install a specific version of [Go Jsonnet](https://github.com/google/go-jsonnet). This action will add
 `jsonnet` and `jsonnetfmt` to the `PATH` making them available for subsequent
 actions.
 

--- a/index.js
+++ b/index.js
@@ -4,73 +4,8 @@ const { exec } = require('@actions/exec')
 const https = require('https')
 const path = require('path')
 
-const fetchReleases = async () => {
-  const version = core.getInput('version')
-  const versionPath = version == 'latest' ? 'tags/0.17.0' : `tags/${version}`
-  const url = `https://api.github.com/repos/google/jsonnet/releases/${versionPath}`
-
-  core.info(`Fetching Jsonnet releases from ${url}`)
-
-  let release
-
-  try {
-    release = JSON.parse(await get(url))
-  } catch (error) {
-    core.setFailed(
-      `Failed to fetch releases from GitHub API, providing a token may help.\nError: ${error}`
-    )
-    return
-  }
-
-  const pattern = new RegExp(`jsonnet-bin-v[0-9.]+-linux\.tar\.gz`, 'i')
-
-  const jsonnetAsset = release.assets.find(asset =>
-    pattern.test(asset.name)
-  )
-
-  return jsonnetAsset.browser_download_url
-}
-
-const get = url => {
-  return new Promise((resolve, reject) => {
-    const headers = {
-      'User-Agent': 'setup-jsonnet Github action',
-    }
-
-    const token = core.getInput('github_token')
-
-    if (token) {
-      headers['Authorization'] = `token ${token}`
-    }
-
-    const request = https.get(url, { headers })
-
-    request.on('response', res => {
-      let data = ''
-
-      res.on('data', chunk => {
-        data += chunk
-      })
-
-      res.on('end', () => {
-        if (res.statusCode == 200) {
-          resolve(data)
-        } else {
-          reject(data)
-        }
-      })
-    })
-
-    request.on('error', err => {
-      reject(err)
-    })
-  })
-}
 
 const run = async () => {
-  //const url = await fetchReleases()
-
-  //await exec(path.join(__dirname, 'install-jsonnet.sh'), [url])
   await exec(path.join(__dirname, 'install-jsonnet.sh'))
 }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ const { exec } = require('@actions/exec')
 const path = require('path')
 
 const run = async () => {
-  await exec(path.join(__dirname, 'install-jsonnet.sh'))
+  const version = core.getInput('version')
+  await exec(path.join(__dirname, 'install-jsonnet.sh'), version)
 }
 
 try {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const fetchReleases = async () => {
   const version = core.getInput('version')
-  const versionPath = version == 'latest' ? 'latest' : `tags/${version}`
+  const versionPath = version == 'latest' ? 'tags/0.17.0' : `tags/${version}`
   const url = `https://api.github.com/repos/google/jsonnet/releases/${versionPath}`
 
   core.info(`Fetching Jsonnet releases from ${url}`)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,6 @@
 const core = require('@actions/core')
-const io = require('@actions/io')
 const { exec } = require('@actions/exec')
-const https = require('https')
 const path = require('path')
-
 
 const run = async () => {
   await exec(path.join(__dirname, 'install-jsonnet.sh'))

--- a/install-jsonnet.sh
+++ b/install-jsonnet.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
 # Install go-jsonnet
-go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
+version="$1"
+go install "github.com/google/go-jsonnet/cmd/jsonnet@${version}"
+go install "github.com/google/go-jsonnet/cmd/jsonnetfmt@${version}"
 
 # Add jsonnet executables to the path for future actions
 echo "$HOME/go/bin" >> "$GITHUB_PATH"

--- a/install-jsonnet.sh
+++ b/install-jsonnet.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 
 # Install go-jsonnet
-go get github.com/google/go-jsonnet/cmd/jsonnet
-go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
 
 # Add jsonnet executables to the path for future actions
 echo "$HOME/go/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Doing some cleanup in this PR:
- I've removed the unused code that downloads the binary from GitHub release page in this PR. 
- Use go install to download jsonnet. This is the recommended way to download executable for Go > 1.16. You can read the [blog post](https://go.dev/blog/go116-module-changes#TOC_4.)
- Updated the tests to verify the downloaded version.



