### PR TITLE
Correctly catch async error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,21 @@ jobs:
         run: jsonnet -v
       - name: Print Jsonnet reformatter version
         run: jsonnetfmt -v
+
+  expected_failure_go:
+    name: Expected failure due to outdated Go version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zendesk/checkout@v2
+      - uses: zendesk/setup-go@v2
+        with:
+          go-version: '1.13.8'
+      - name: Setup Jsonnet
+        uses: ./
+        continue-on-error: true
+        id: jsonnet
+        with:
+          github_token: ${{ github.token }}
+      - name: Expect failure
+        run: |
+          [[ "${{ steps.jsonnet.outcome }}" == "failure" ]] && [[ "${{ steps.jsonnet.conclusion }}" == "success" ]]

--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ const { exec } = require('@actions/exec')
 const path = require('path')
 
 const run = async () => {
-  const version = core.getInput('version')
-  await exec(path.join(__dirname, 'install-jsonnet.sh'), version)
+  try {
+    const version = core.getInput('version')
+    await exec(path.join(__dirname, 'install-jsonnet.sh'), version)
+  } catch (error) {
+    core.setFailed(`Action failed with error: ${error}`)
+  }
 }
 
-try {
-  run()
-} catch (error) {
-  core.setFailed(`Action failed with error: ${error}`)
-}
+run()


### PR DESCRIPTION
Since run() is async, any error from it won't be caught by the catch
directive below. For example, [1] should have failed in setup-jsonnet
stage however it carried on.

[1] https://github.com/zendesk/zorg-ui/runs/4714323764?check_suite_focus=true
