### PR TITLE
[SPACE-2231] Update setup-jsonnet action to include style and lint utilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: Install specific version of Jsonnet and print version
     runs-on: ubuntu-latest
     env:
-      version: v0.16.0
+      version: v0.18.0
     steps:
       - uses: zendesk/checkout@v2
       - uses: zendesk/setup-go@v2
@@ -34,6 +34,22 @@ jobs:
             echo "Cannot find $version"
             echo 1
           fi
+      - name: Print Jsonnet dependency parser version
+        run: |
+          jsonnet_version=$(jsonnet-deps -v)
+          echo "$jsonnet_version"
+          if [[ ${jsonnet_version} != *"$version"* ]];then
+            echo "Cannot find $version"
+            echo 1
+          fi
+      - name: Print Jsonnet linter version
+        run: |
+          jsonnet_version=$(jsonnet-lint -v)
+          echo "$jsonnet_version"
+          if [[ ${jsonnet_version} != *"$version"* ]];then
+            echo "Cannot find $version"
+            echo 1
+          fi
 
   install_latest:
     name: Install latest version of Jsonnet and print version
@@ -51,6 +67,10 @@ jobs:
         run: jsonnet -v
       - name: Print Jsonnet reformatter version
         run: jsonnetfmt -v
+      - name: Print Jsonnet dependency parser version
+        run: jsonnet-deps -v
+      - name: Print Jsonnet linter version
+        run: jsonnet-lint -v
 
   expected_failure_go:
     name: Expected failure due to outdated Go version

--- a/README.md
+++ b/README.md
@@ -3,16 +3,12 @@
 ![Latest Release](https://img.shields.io/github/v/release/zendesk/setup-jsonnet?label=Latest%20Release)
 ![Examples](https://github.com/zendesk/setup-jsonnet/workflows/Test/badge.svg?branch=master)
 
-A GitHub action to install a specific version of [Go Jsonnet](https://github.com/google/go-jsonnet). This action will add
-`jsonnet` and `jsonnetfmt` to the `PATH` making them available for subsequent
-actions.
+A GitHub action to install a specific version of [Go Jsonnet](https://github.com/google/go-jsonnet). This action will add `jsonnet`, `jsonnetfmt`, `jsonnet-deps` and `jsonnet-lint` to the `PATH`, making them available for subsequent actions.
 
 ## Inputs
 
-* `version` - specifies the version of Jsonnet file to be installed. Required, 
-defaults to `latest`
-* `github_token` -  A GitHub Token. This can help with rate limits when 
-fetching releases. Optional
+* `version` - specifies the version of Jsonnet file to be installed. Required,  defaults to `latest`.
+* `github_token` -  A GitHub Token. This can help with rate limits when fetching releases (optional).
 
 ## Output
 

--- a/install-jsonnet.sh
+++ b/install-jsonnet.sh
@@ -4,6 +4,8 @@
 version="$1"
 go install "github.com/google/go-jsonnet/cmd/jsonnet@${version}"
 go install "github.com/google/go-jsonnet/cmd/jsonnetfmt@${version}"
+go install "github.com/google/go-jsonnet/cmd/jsonnet-deps@${version}"
+go install "github.com/google/go-jsonnet/cmd/jsonnet-lint@${version}"
 
 # Add jsonnet executables to the path for future actions
 echo "$HOME/go/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
### Description

/cc @shoukoo, @everops-alex

Adding style and lint binaries to match Homebrew installation.

### Verification

After merging, check that the release was published correctly: https://github.com/zendesk/setup-jsonnet/releases

### References

- JIRA: https://zendesk.atlassian.net/browse/SPACE-2231

### Risks

- Low: Low impact. Incremental additions.
- Rollback: Remove faulty release
